### PR TITLE
fix: Update project name from "Follow" to "Folo" and fix related links

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,14 +9,14 @@ RSS and the open information it represents will never die, because we steadfast 
 </a>
 
 <p>
-<a href="https://github.com/RSSNext/Follow">
-<strong>Follow - Follow your favorites in one inbox</strong>
+<a href="https://github.com/RSSNext/Folo">
+<strong>Folo - Follow everything in one place</strong>
 </a>
 </p>
 
 As they say, your thoughts are what you read—and we’ve been consuming noisy feeds for too long! Follow organizes content into one timeline, keeping you updated on what matters, noise-free. Share lists, explore collections, and enjoy distraction-free browsing.
 
-<img src="https://img.shields.io/github/stars/RSSNext/Follow?color=ffcb47&labelColor=black&style=flat-square&logo=github" alt="Follow" />
+<img src="https://img.shields.io/github/stars/RSSNext/Folo?color=ffcb47&labelColor=black&style=flat-square&logo=github" alt="Folo" />
 
 ---
 


### PR DESCRIPTION
I noticed that the project has been renamed from "Follow" to "Folo". This pull request updates all references to the project name.